### PR TITLE
Add support for php ^8.0 and psr/cache ^2.0 and ^3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
   - '7.2'
   - '7.3'
   - '7.4'
+  - '8.0'
+  - '8.1'
+  - '8.2'
 
 env:
   - COMPOSER_FLAGS='update --prefer-lowest --prefer-stable'

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 || ^8.0",
     "psr/http-message": "^1.0",
-    "psr/cache": "^1.0",
+    "psr/cache": "^1.0 || ^2.0 || ^3.0",
     "psr/http-client-implementation": "^1.0",
     "psr/http-factory-implementation": "^1.0",
     "php-http/httplug": "^2.0",


### PR DESCRIPTION
References pull request #2, adding support for:
- php `^7.2 || ^8.0`
- psr/cache `^1.0 || ^2.0 || ^3.0`